### PR TITLE
Remove 'Set [...] as content directory'

### DIFF
--- a/lib/metadata.js
+++ b/lib/metadata.js
@@ -14,8 +14,6 @@ var parseDate = function (dateAsString) {
 };
 
 var loadMetadataInDirectory = function (options, baseDirectory, callback) {
-    console.log('Set', baseDirectory, 'as content directory');
-
     glob('**/' + constants.DEFAULT_METADATA_FILENAME, { cwd: baseDirectory }, function (err, results) {
         var metadata = [];
 


### PR DESCRIPTION
I think this log must not be shown. As Bloggy is an NPM module, it should not output undesired content (see [this article](https://blog.risingstack.com/node-js-logging-tutorial/#logginginnodejsmodules)).